### PR TITLE
Fix approov xcframework spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/android/a
 Do the same for iOS:
 
 ```text
-approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/approov.xcframework
+approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/Approov.xcframework
 ```
 > **NOTE:** The approov command is downloading the Approov SDK into the folder `your-project/approov/flutter-httpclient/approov_http_client/ios`
 

--- a/src/app-final/README.md
+++ b/src/app-final/README.md
@@ -60,7 +60,7 @@ approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/android/a
 Do the same for iOS by executing from `src/app-final` folder:
 
 ```text
-approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/approov.xcframework
+approov sdk -getLibrary approov/flutter-httpclient/approov_http_client/ios/Approov.xcframework
 ```
 > **NOTE:** The approov command is downloading the Approov SDK into the folder `src/app/final/approov/flutter-httpclient/approov_http_client/ios`
 


### PR DESCRIPTION
Spelling the name with a lowercase 'a' causes a build failure (or a run-time link failure in the simulator).